### PR TITLE
Update zzseotk.php

### DIFF
--- a/zzseotk.php
+++ b/zzseotk.php
@@ -307,6 +307,10 @@ class zzSeoTK extends Module
         $getLinkFunc = 'get'.ucfirst($controller).'Link';
         $params = array();
 
+        // Define language and shop from PS context
+		$id_lang = $this->context->language->id;
+		$id_shop = $this->context->shop->id;
+
         if (!$link || !$controller) {
             return;
         }
@@ -321,12 +325,28 @@ class zzSeoTK extends Module
                 $canonical = $link->getCategoryLink($id, null, $id_lang, Tools::getValue('selected_filters', null), $id_shop);
                 break;
             case 'cms':
-                // getCMSLink($cms, $alias = null, $ssl = null, $id_lang = null, $id_shop = null, $relative_protocol = false)
-                $canonical = $link->getCmsLink($id, null, null, $id_lang, $id_shop);
+                // PrestaShop 1.6 seems to handle cms-category with module name "cms" but id "id_cms_category"
+                // Check for that to generate the right canonical URL
+			    if( $_GET['id_cms'] ) {
+                  // getCMSLink($cms, $alias = null, $ssl = null, $id_lang = null, $id_shop = null, $relative_protocol = false)
+                  $canonical = $link->getCmsLink($id, null, null, $id_lang, $id_shop);
+				}
+				elseif( $_GET['id_cms_category'] ) {
+				  // getCMSCategoryLink($cms_category, $alias = null, $id_lang = null, $id_shop = null, $relative_protocol = false)
+				  $canonical = $link->getCMSCategoryLink($_GET['id_cms_category'], null, $id_lang, $id_shop);
+				}
                 break;
-
+            // This one handles the custom blog pages of Leo Theme themes
+			case 'blogleoblog':
+                $blog = new LeoBlogBlog( $_GET['id'], $id_lang );
+                $_params = $_GET;
+				$_params['rewrite'] = $blog->link_rewrite;
+				$canonical = $link->getModuleLink($module, $controller, $_params, null, $id_lang, $id_shop);
+			    break;
+            // This one is not used (see above)
             case 'cms-category':
                 // getCMSCategoryLink ($cms_category, $alias = null, $id_lang = null, $id_shop = null, $relative_protocol = false)
+            // Probably missing; not tested
             case 'supplier':
                 // getSupplierLink    ($supplier,     $alias = null, $id_lang = null, $id_shop = null, $relative_protocol = false)
             case 'manufacturer':


### PR DESCRIPTION
Hello,

  Thanks a lot for your module. You have done a great job! I have implemented it in a test environment and added a few things so that it takes care of more cases for canonical URL´s. This test environment is a Prestashop 1.6.0.11. Then I have deployed it in our multishop and tested there, which is a Prestashop 1.6.0.9. It works on both. In fact it is being used as I write this.

  Best Regards,

  Javier Elices.

PS: I have activated canonical and noindex. The canonical option I have tested extensively and everything seems to work fine. Noindex seems to work too, but as I am sure you know better, could you propose a robots.txt to go with that option? The robots.txt that Prestashop generates is too complex and may cause trouble if you use URL´s with campaign tags. I have modified it a little but would love to see what you propose. Thanks again!
